### PR TITLE
support varbinary and geometry types

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -61,6 +61,8 @@ endif()
 
 if(TODBC_WINDOWS)
     set_source_files_properties(tb.c PROPERTIES COMPILE_OPTIONS "/source-charset:utf-8")
+else()
+    target_link_libraries(tb pthread)
 endif()
 
 add_executable(ob
@@ -70,7 +72,7 @@ add_executable(ob
     ob.c
 )
 if(NOT TODBC_WINDOWS)
-    target_link_libraries(ob odbc)
+    target_link_libraries(ob odbc pthread)
 else()
     target_link_libraries(ob odbc32)
     set_source_files_properties(ob.c PROPERTIES COMPILE_OPTIONS "/source-charset:utf-8")

--- a/common/taos_helpers.c
+++ b/common/taos_helpers.c
@@ -141,6 +141,14 @@ int helper_get_tsdb_ws(int time_precision, const char *name, uint8_t col_type, c
         tsdb->str.len = strnlen(col, col_len); // FIXME:
         tsdb->str.encoder = NULL;
       } break;
+    case TSDB_DATA_TYPE_VARBINARY:
+    case TSDB_DATA_TYPE_GEOMETRY:
+      {
+        char *col = (char*)col_data;
+        tsdb->str.str = col;
+        tsdb->str.len = col_len;
+        tsdb->str.encoder = NULL;
+      } break;
     case TSDB_DATA_TYPE_TIMESTAMP:
       {
         int64_t *col = (int64_t*)col_data;
@@ -239,6 +247,8 @@ int helper_get_tsdb(TAOS_RES *res, int block, TAOS_FIELD *fields, int time_preci
     case TSDB_DATA_TYPE_VARCHAR:
     case TSDB_DATA_TYPE_NCHAR:
     case TSDB_DATA_TYPE_JSON:
+    case TSDB_DATA_TYPE_VARBINARY:
+    case TSDB_DATA_TYPE_GEOMETRY:
       if (block) {
         int *offsets = CALL_taos_get_column_data_offset(res, i_col);
         char *col = (char*)(rows[i_col]);

--- a/inc/helpers.h
+++ b/inc/helpers.h
@@ -59,6 +59,13 @@ int tod_conv(const char *fromcode, const char *tocode, const char *src, size_t s
 #define tod_strncasecmp     strncasecmp
 #endif
 
+typedef uint16_t VarDataLenT;  // maxVarDataLen: 65535
+#define VARSTR_HEADER_SIZE sizeof(VarDataLenT)
+
+#define varDataLen(v)  ((VarDataLenT *)(v))[0]
+#define varDataVal(v)  ((char *)(v) + VARSTR_HEADER_SIZE)
+#define varDataTLen(v) (sizeof(VarDataLenT) + varDataLen(v))
+
 EXTERN_C_END
 
 #endif // _helpers_h_

--- a/src/core/desc.c
+++ b/src/core/desc.c
@@ -258,14 +258,8 @@ SQLRETURN descriptor_bind_col(descriptor_t *ARD,
       ARD_record->DESC_OCTET_LENGTH      = ARD_record->DESC_LENGTH;
       break;
     case SQL_C_CHAR:
-      ARD_record->DESC_LENGTH            = 0; // FIXME:
-      ARD_record->DESC_PRECISION         = 0;
-      ARD_record->DESC_SCALE             = 0;
-      ARD_record->DESC_TYPE              = TargetType;
-      ARD_record->DESC_CONCISE_TYPE      = TargetType;
-      ARD_record->DESC_OCTET_LENGTH      = BufferLength;
-      break;
     case SQL_C_WCHAR:
+    case SQL_C_BINARY:
       ARD_record->DESC_LENGTH            = 0; // FIXME:
       ARD_record->DESC_PRECISION         = 0;
       ARD_record->DESC_SCALE             = 0;

--- a/src/core/internal.h
+++ b/src/core/internal.h
@@ -305,7 +305,7 @@ struct get_data_ctx_s {
   sqlc_data_t    sqlc;
 
   //
-  char           buf[64];
+  char           buf[1024];
   mem_t          mem;
 
   const char    *pos;

--- a/src/core/stmt.c
+++ b/src/core/stmt.c
@@ -2594,11 +2594,13 @@ static SQLRETURN _stmt_get_data_copy_binary(stmt_t *stmt, const char *s, size_t 
 {
   get_data_ctx_t *ctx = &stmt->get_data_ctx;
   tsdb_data_t *tsdb = &ctx->tsdb;
+  int size = 0;
   switch (args->TargetType) {
     case SQL_C_CHAR:
-      ctx->nr = tsdb_binary_to_string(tsdb->str.str, tsdb->str.len, (char*)ctx->buf, sizeof(ctx->buf));
+      size = tsdb_binary_to_string(s, nr, (char*)ctx->buf, sizeof(ctx->buf));
+      if (size < 0) return SQL_ERROR;
+      ctx->nr = (size_t)size;
       ctx->pos = ctx->buf;
-      if (ctx->nr == -1) return SQL_ERROR;
       return _stmt_get_data_copy_buf_to_char(stmt, args);
     case SQL_C_BINARY:
       return _stmt_get_data_copy_buf_to_binary(stmt, args);

--- a/src/core/tsdb.c
+++ b/src/core/tsdb.c
@@ -122,6 +122,14 @@ int tsdb_timestamp_to_string(int64_t val, int time_precision, char *buf, size_t 
   return n;
 }
 
+int tsdb_binary_to_string(const char *str, size_t n, char *buf, size_t len)
+{
+  size_t size = len;
+  int32_t r = byte2hex(str, n, buf, &size);
+  if (r) return -1;
+  return (int)size;
+}
+
 static void _tsdb_param_column_release(tsdb_param_column_t *pa)
 {
   mem_release(&pa->mem);

--- a/src/core/tsdb.c
+++ b/src/core/tsdb.c
@@ -125,7 +125,7 @@ int tsdb_timestamp_to_string(int64_t val, int time_precision, char *buf, size_t 
 int tsdb_binary_to_string(const char *str, size_t n, char *buf, size_t len)
 {
   size_t size = len;
-  int32_t r = byte2hex(str, n, buf, &size);
+  int32_t r = byte2hex((const uint8_t *)str, n, (uint8_t *)buf, &size);
   if (r) return -1;
   return (int)size;
 }

--- a/src/inc/tsdb.h
+++ b/src/inc/tsdb.h
@@ -34,6 +34,7 @@ EXTERN_C_BEGIN
 
 int tsdb_timestamp_to_string(int64_t val, int time_precision, char *buf, size_t len) FA_HIDDEN;
 int tsdb_timestamp_to_SQL_C_TYPE_TIMESTAMP(int64_t val, int time_precision, SQL_TIMESTAMP_STRUCT *ts) FA_HIDDEN;
+int tsdb_binary_to_string(const char *str, size_t n, char *buf, size_t len) FA_HIDDEN;
 
 void tsdb_stmt_reset(tsdb_stmt_t *stmt) FA_HIDDEN;
 void tsdb_stmt_release(tsdb_stmt_t *stmt) FA_HIDDEN;

--- a/src/inc/utils.h
+++ b/src/inc/utils.h
@@ -30,6 +30,7 @@
 #include "iconv_wrapper.h"
 
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -227,6 +228,10 @@ void strs_release(strs_t *strs) FA_HIDDEN;
 int strs_keep(strs_t *strs, size_t cap) FA_HIDDEN;
 int strs_flat(strs_t *strs, str_t *str) FA_HIDDEN;
 
+uint8_t is_hex(const uint8_t *z, size_t n) FA_HIDDEN;
+uint8_t is_validate_hex(const uint8_t *z, size_t n) FA_HIDDEN;
+int32_t byte2hex(const uint8_t *z, size_t n, uint8_t *data, size_t *size) FA_HIDDEN;
+int32_t hex2byte(const uint8_t *z, size_t n, uint8_t *data, size_t *size) FA_HIDDEN;
 
 EXTERN_C_END
 

--- a/tests/c/api_test.c
+++ b/tests/c/api_test.c
@@ -453,7 +453,7 @@ static int do_sql_stmt_execute_binary_col(SQLHANDLE stmth)
     }
   };
 
-  char sql[256];
+  char sql[1024];
   (void)snprintf(sql, sizeof(sql), "insert into tb1 using stb tags(1) values(now, 1, '%s', '%s', '%s')", check_cb.cols[0].col_literal, check_cb.cols[1].col_literal, check_cb.cols[2].col_literal);
 
   CHK2(test_sql_stmt_execute_direct, stmth, "drop stable if exists stb", 0);

--- a/tests/c/api_test.c
+++ b/tests/c/api_test.c
@@ -306,7 +306,7 @@ static int _sql_stmt_get_data(SQLHANDLE stmth, SQLSMALLINT ColumnCount, col_chec
       continue;
     }
     
-    if (0 <= StrLen_or_Ind < BufferLength) buf[StrLen_or_Ind] = '\0';
+    if (0 <= StrLen_or_Ind && StrLen_or_Ind < BufferLength) buf[StrLen_or_Ind] = '\0';
     D("Column[#%d]: [%s]", i, buf);
 
     if (check) {


### PR DESCRIPTION
support varbinary and geometry types
1. Type mapping
Add the varbinary/geometry type in _stmt_fill_IRD and _col_bind_map

2. Read the original content
Add varbinary/geometry types to the helper_get_tsdb_ws and helper_get_tsdb functions

3. Two-level system conversion
Add geometry type in function _stmt_get_data_prepare_ctx

4, server coding ==> client coding conversion
Function _stmt_get_data_copy adds the implementation of TSDB_DATA_TYPE_VARBINARY/TSDB_DATA_TYPE_GEOMETRY

5. Add the varbinary/geometry test case to the api_test.c file